### PR TITLE
タスク1-1 + 1-3の一部：ユーザー登録フォームの実装

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,5 +1,5 @@
+import { Box, Typography } from '@mui/material';
 import React from 'react';
-import { Typography, Box } from '@mui/material';
 
 const HomePage: React.FC = () => {
   return (

--- a/app/register/page.tsx
+++ b/app/register/page.tsx
@@ -2,13 +2,17 @@
 
 'use client'; // クライアントコンポーネントとしてマーク
 
+import { useRouter } from 'next/navigation';
 import React from 'react';
 import RegisterForm from '../../components/RegisterForm';
 
 // TODO: 新規登録ページを実装し、RegisterFormコンポーネントを使用する
 const RegisterPage: React.FC = () => {
+
+  const router = useRouter()
+
   return (
-    <RegisterForm></RegisterForm>
+    <RegisterForm onSuccess={() => router.push('/users')} onError={(errorMsg) => alert(errorMsg)} disabled={false}></RegisterForm>
   );
 }
 

--- a/app/register/page.tsx
+++ b/app/register/page.tsx
@@ -1,0 +1,15 @@
+// app/register/page.tsx
+
+'use client'; // クライアントコンポーネントとしてマーク
+
+import React from 'react';
+import RegisterForm from '../../components/RegisterForm';
+
+// TODO: 新規登録ページを実装し、RegisterFormコンポーネントを使用する
+const RegisterPage: React.FC = () => {
+  return (
+    <RegisterForm></RegisterForm>
+  );
+}
+
+export default RegisterPage;

--- a/components/RegisterForm.tsx
+++ b/components/RegisterForm.tsx
@@ -1,0 +1,70 @@
+// components/RegisterForm.tsx
+
+import { Box, Button, TextField, Typography } from "@mui/material";
+import React from "react";
+import { useForm } from "react-hook-form";
+
+// 必要に応じて利用する
+interface RegisterFormInputs {
+  name: string;
+  email: string;
+  role: string;
+}
+
+// データ登録時ページ遷移情報
+interface RegisterFormProps {
+ onSuccess?: () => void;
+ onError?: (error: any) => void;
+ disabled?: boolean;
+}
+
+
+// TODO: 新規登録フォームコンポーネントを実装する
+const RegisterForm: React.FC = (props: RegisterFormProps) => {
+  // 必要に応じて利用する
+  const {
+    register,
+    handleSubmit,
+    formState: { errors },
+  } = useForm<RegisterFormInputs>();
+
+  // 登録実行
+  // const onSubmit = () => {
+  //   createUser()
+  // }
+
+  return (
+    <Box sx={{ maxWidth: 400, mx: "auto", mt: 4 }}>
+      <Typography  variant="h5" gutterBottom>
+        新規登録
+      </Typography>
+
+      {/* TODO: createUserを呼び出す為の関数を呼び出す必要がある */}
+      <form onSubmit={handleSubmit(props.onSuccess!, props.onError)}>
+        <TextField label="User Name" sx={{m: 2}} {
+          ...register('name', {required: '名前を入力してください'})
+        }></TextField>
+        {errors.name && (
+          <Typography color='error'>{errors.name.message}</Typography>
+        )}
+        <TextField label="Email Adress" type="email" sx={{m: 2}} {
+          ...register('email', {required: 'メールアドレスを入力してください'})
+        }></TextField>
+        {errors.email && (
+          <Typography color='error'>{errors.email.message}</Typography>
+        )}
+        <TextField label="User Role" sx={{m: 2}} {
+          ...register('role', {required: '権限を入力してください'})
+        }></TextField>
+        {errors.role && (
+          <Typography color='error'>{errors.role.message}</Typography>
+        )}
+        <Box sx={{m: 3}}>
+          <Button variant="contained" disabled={props.disabled} type="submit">登録</Button>
+        </Box>
+      </form>
+    </Box>
+  );
+};
+
+export default RegisterForm;

--- a/components/RegisterForm.tsx
+++ b/components/RegisterForm.tsx
@@ -2,7 +2,7 @@
 
 import { createUser } from "@/utils/api";
 import { Box, Button, TextField, Typography } from "@mui/material";
-import React from "react";
+import React, { useEffect, useState } from "react";
 import { useForm } from "react-hook-form";
 
 // 必要に応じて利用する
@@ -14,14 +14,20 @@ interface RegisterFormInputs {
 
 // データ登録時ページ遷移情報
 interface RegisterFormProps {
- onSuccess?: () => void;
- onError?: (error: any) => void;
- disabled?: boolean;
+ onSuccess: () => void;
+ onError: (error: any) => void;
+ disabled: boolean;
 }
 
+const RegisterForm: React.FC<RegisterFormProps> = (props: RegisterFormProps) => {
 
-// TODO: 新規登録フォームコンポーネントを実装する
-const RegisterForm: React.FC = (props: RegisterFormProps) => {
+  // 登録ボタン連続押下防止
+  const [registerBtnDistabled, setRegisterBtnDistabled] = useState<boolean>(false);
+
+  useEffect(() => {
+    setRegisterBtnDistabled(props.disabled);
+  }, []);
+
   // 必要に応じて利用する
   const {
     register,
@@ -31,14 +37,14 @@ const RegisterForm: React.FC = (props: RegisterFormProps) => {
 
   // 登録実行
   const execSubmit = async (formData: RegisterFormInputs) => {
+    setRegisterBtnDistabled(true);
     try {
-      console.log('formData', formData);
-      const response = await createUser(formData);
-      console.log('response', response);
-      if (props.onSuccess) props.onSuccess();
+      await createUser(formData);
+      props.onSuccess(); 
     } catch (err) {
-      console.log('ユーザーの取得に失敗しました。', err);
-      if (props.onError) props.onError(err);
+      props.onError(err);
+      // ボタンを再押下可能に
+      setRegisterBtnDistabled(false);
     } 
   };
 
@@ -68,7 +74,7 @@ const RegisterForm: React.FC = (props: RegisterFormProps) => {
           <Typography color='error'>{errors.role.message}</Typography>
         )}
         <Box sx={{m: 3}}>
-          <Button variant="contained" disabled={props.disabled} type="submit">登録</Button>
+          <Button variant="contained" disabled={registerBtnDistabled} type="submit">登録</Button>
         </Box>
       </form>
     </Box>

--- a/components/RegisterForm.tsx
+++ b/components/RegisterForm.tsx
@@ -1,5 +1,6 @@
 // components/RegisterForm.tsx
 
+import { createUser } from "@/utils/api";
 import { Box, Button, TextField, Typography } from "@mui/material";
 import React from "react";
 import { useForm } from "react-hook-form";
@@ -29,18 +30,25 @@ const RegisterForm: React.FC = (props: RegisterFormProps) => {
   } = useForm<RegisterFormInputs>();
 
   // 登録実行
-  // const onSubmit = () => {
-  //   createUser()
-  // }
+  const execSubmit = async (formData: RegisterFormInputs) => {
+    try {
+      console.log('formData', formData);
+      const response = await createUser(formData);
+      console.log('response', response);
+      if (props.onSuccess) props.onSuccess();
+    } catch (err) {
+      console.log('ユーザーの取得に失敗しました。', err);
+      if (props.onError) props.onError(err);
+    } 
+  };
 
   return (
-    <Box sx={{ maxWidth: 400, mx: "auto", mt: 4 }}>
+    <Box sx={{ maxWidth: 400, mx: "auto", mt: 4, textAlign: 'center' }}>
       <Typography  variant="h5" gutterBottom>
         新規登録
       </Typography>
 
-      {/* TODO: createUserを呼び出す為の関数を呼び出す必要がある */}
-      <form onSubmit={handleSubmit(props.onSuccess!, props.onError)}>
+      <form onSubmit={handleSubmit(execSubmit)}>
         <TextField label="User Name" sx={{m: 2}} {
           ...register('name', {required: '名前を入力してください'})
         }></TextField>


### PR DESCRIPTION
「タスク1-1 ：新規登録画⾯コンポーネントの作成」 を実装しました。  
※「タスク1-3：新規登録ページの作成」の内容も部分的に含まれます。

## 対応内容

### タスク1-1の実装  
- [x] ：ユーザー登録APIの実行に成功する
- [x] ：登録成功後はユーザー一覧画面に遷移する

### タスク1-3の実装
- [x] ：`RegisterForm`コンポーネントを呼び出している
- [x] ：ページ全体のレイアウトが崩れていない
- [x] ：タスク1-1のユーザー⼀覧画⾯に遷移する仕組みが実装されている
- [ ]  ：新規登録ページへのリンクが上部メニューに追加されている　→  本仕様は後続ブランチで対応予定