### PR TITLE
タスク1-3：新規登録ページの作成

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,5 +1,5 @@
+import { Box, Typography } from '@mui/material';
 import React from 'react';
-import { Typography, Box } from '@mui/material';
 
 const HomePage: React.FC = () => {
   return (

--- a/app/register/page.tsx
+++ b/app/register/page.tsx
@@ -2,13 +2,17 @@
 
 'use client'; // クライアントコンポーネントとしてマーク
 
+import { useRouter } from 'next/navigation';
 import React from 'react';
 import RegisterForm from '../../components/RegisterForm';
 
 // TODO: 新規登録ページを実装し、RegisterFormコンポーネントを使用する
 const RegisterPage: React.FC = () => {
+
+  const router = useRouter()
+
   return (
-    <RegisterForm></RegisterForm>
+    <RegisterForm onSuccess={() => router.push('/users')} onError={(errorMsg) => alert(errorMsg)} disabled={false}></RegisterForm>
   );
 }
 

--- a/app/register/page.tsx
+++ b/app/register/page.tsx
@@ -1,0 +1,15 @@
+// app/register/page.tsx
+
+'use client'; // クライアントコンポーネントとしてマーク
+
+import React from 'react';
+import RegisterForm from '../../components/RegisterForm';
+
+// TODO: 新規登録ページを実装し、RegisterFormコンポーネントを使用する
+const RegisterPage: React.FC = () => {
+  return (
+    <RegisterForm></RegisterForm>
+  );
+}
+
+export default RegisterPage;

--- a/app/register/page.tsx
+++ b/app/register/page.tsx
@@ -6,7 +6,6 @@ import { useRouter } from 'next/navigation';
 import React from 'react';
 import RegisterForm, { type RegisterFormInputs } from '../../components/RegisterForm';
 
-// TODO: 新規登録ページを実装し、RegisterFormコンポーネントを使用する
 const RegisterPage: React.FC = () => {
 
   const router = useRouter()

--- a/app/register/page.tsx
+++ b/app/register/page.tsx
@@ -4,7 +4,7 @@
 
 import { useRouter } from 'next/navigation';
 import React from 'react';
-import RegisterForm from '../../components/RegisterForm';
+import RegisterForm, { type RegisterFormInputs } from '../../components/RegisterForm';
 
 // TODO: 新規登録ページを実装し、RegisterFormコンポーネントを使用する
 const RegisterPage: React.FC = () => {
@@ -12,7 +12,7 @@ const RegisterPage: React.FC = () => {
   const router = useRouter()
 
   return (
-    <RegisterForm onSuccess={() => router.push('/users')} onError={(errorMsg) => alert(errorMsg)} disabled={false}></RegisterForm>
+    <RegisterForm onSuccess={(formData: RegisterFormInputs) => router.push('/users')} onError={(errorMsg) => alert(errorMsg)} disabled={false}></RegisterForm>
   );
 }
 

--- a/components/Navbar.tsx
+++ b/components/Navbar.tsx
@@ -1,6 +1,6 @@
-import React from 'react';
+import { AppBar, Button, Toolbar, Typography } from '@mui/material';
 import Link from 'next/link';
-import { AppBar, Toolbar, Typography, Button } from '@mui/material';
+import React from 'react';
 
 const Navbar: React.FC = () => {
   return (
@@ -14,6 +14,9 @@ const Navbar: React.FC = () => {
         </Button>
         <Button color="inherit" component={Link} href="/users">
           ユーザー一覧
+        </Button>
+        <Button color="inherit" component={Link} href="/register">
+          ユーザー登録
         </Button>
       </Toolbar>
     </AppBar>

--- a/components/RegisterForm.stories.tsx
+++ b/components/RegisterForm.stories.tsx
@@ -1,0 +1,30 @@
+// components/RegisterForm.stories.tsx
+
+import type { Meta, StoryObj } from "@storybook/react";
+import RegisterForm, { type RegisterFormInputs } from "./RegisterForm";
+
+// メタデータ
+const meta: Meta<typeof RegisterForm> = {
+  title: 'Components/RegisterForm',
+  component: RegisterForm,
+};
+
+export default meta;
+// ストーリーの定義
+type Story = StoryObj<typeof RegisterForm>;
+
+// デフォルトストーリーの設定
+export const Default: Story = {
+  args: {
+    onSuccess: (formData: RegisterFormInputs) => {
+      alert(`
+        ユーザー登録成功
+        name: ${formData.name}\n
+        email: ${formData.email}\n
+        role: ${formData.role}\n
+      `)
+    },
+    onError: (errorMsg) => alert(errorMsg),
+    disabled: false,
+  },
+};

--- a/components/RegisterForm.tsx
+++ b/components/RegisterForm.tsx
@@ -1,0 +1,70 @@
+// components/RegisterForm.tsx
+
+import { Box, Button, TextField, Typography } from "@mui/material";
+import React from "react";
+import { useForm } from "react-hook-form";
+
+// 必要に応じて利用する
+interface RegisterFormInputs {
+  name: string;
+  email: string;
+  role: string;
+}
+
+// データ登録時ページ遷移情報
+interface RegisterFormProps {
+ onSuccess?: () => void;
+ onError?: (error: any) => void;
+ disabled?: boolean;
+}
+
+
+// TODO: 新規登録フォームコンポーネントを実装する
+const RegisterForm: React.FC = (props: RegisterFormProps) => {
+  // 必要に応じて利用する
+  const {
+    register,
+    handleSubmit,
+    formState: { errors },
+  } = useForm<RegisterFormInputs>();
+
+  // 登録実行
+  // const onSubmit = () => {
+  //   createUser()
+  // }
+
+  return (
+    <Box sx={{ maxWidth: 400, mx: "auto", mt: 4 }}>
+      <Typography  variant="h5" gutterBottom>
+        新規登録
+      </Typography>
+
+      {/* TODO: createUserを呼び出す為の関数を呼び出す必要がある */}
+      <form onSubmit={handleSubmit(props.onSuccess!, props.onError)}>
+        <TextField label="User Name" sx={{m: 2}} {
+          ...register('name', {required: '名前を入力してください'})
+        }></TextField>
+        {errors.name && (
+          <Typography color='error'>{errors.name.message}</Typography>
+        )}
+        <TextField label="Email Adress" type="email" sx={{m: 2}} {
+          ...register('email', {required: 'メールアドレスを入力してください'})
+        }></TextField>
+        {errors.email && (
+          <Typography color='error'>{errors.email.message}</Typography>
+        )}
+        <TextField label="User Role" sx={{m: 2}} {
+          ...register('role', {required: '権限を入力してください'})
+        }></TextField>
+        {errors.role && (
+          <Typography color='error'>{errors.role.message}</Typography>
+        )}
+        <Box sx={{m: 3}}>
+          <Button variant="contained" disabled={props.disabled} type="submit">登録</Button>
+        </Box>
+      </form>
+    </Box>
+  );
+};
+
+export default RegisterForm;

--- a/components/RegisterForm.tsx
+++ b/components/RegisterForm.tsx
@@ -2,7 +2,7 @@
 
 import { createUser } from "@/utils/api";
 import { Box, Button, TextField, Typography } from "@mui/material";
-import React from "react";
+import React, { useEffect, useState } from "react";
 import { useForm } from "react-hook-form";
 
 // 必要に応じて利用する
@@ -14,14 +14,20 @@ interface RegisterFormInputs {
 
 // データ登録時ページ遷移情報
 interface RegisterFormProps {
- onSuccess?: () => void;
- onError?: (error: any) => void;
- disabled?: boolean;
+ onSuccess: () => void;
+ onError: (error: any) => void;
+ disabled: boolean;
 }
 
+const RegisterForm: React.FC<RegisterFormProps> = (props: RegisterFormProps) => {
 
-// TODO: 新規登録フォームコンポーネントを実装する
-const RegisterForm: React.FC = (props: RegisterFormProps) => {
+  // 登録ボタン連続押下防止
+  const [registerBtnDistabled, setRegisterBtnDistabled] = useState<boolean>(false);
+
+  useEffect(() => {
+    setRegisterBtnDistabled(props.disabled);
+  }, []);
+
   // 必要に応じて利用する
   const {
     register,
@@ -31,14 +37,14 @@ const RegisterForm: React.FC = (props: RegisterFormProps) => {
 
   // 登録実行
   const execSubmit = async (formData: RegisterFormInputs) => {
+    setRegisterBtnDistabled(true);
     try {
-      console.log('formData', formData);
-      const response = await createUser(formData);
-      console.log('response', response);
-      if (props.onSuccess) props.onSuccess();
+      await createUser(formData);
+      props.onSuccess(); 
     } catch (err) {
-      console.log('ユーザーの取得に失敗しました。', err);
-      if (props.onError) props.onError(err);
+      props.onError(err);
+      // ボタンを再押下可能に
+      setRegisterBtnDistabled(false);
     } 
   };
 
@@ -68,7 +74,7 @@ const RegisterForm: React.FC = (props: RegisterFormProps) => {
           <Typography color='error'>{errors.role.message}</Typography>
         )}
         <Box sx={{m: 3}}>
-          <Button variant="contained" disabled={props.disabled} type="submit">登録</Button>
+          <Button variant="contained" disabled={registerBtnDistabled} type="submit">登録</Button>
         </Box>
       </form>
     </Box>

--- a/components/RegisterForm.tsx
+++ b/components/RegisterForm.tsx
@@ -1,5 +1,6 @@
 // components/RegisterForm.tsx
 
+import { createUser } from "@/utils/api";
 import { Box, Button, TextField, Typography } from "@mui/material";
 import React from "react";
 import { useForm } from "react-hook-form";
@@ -29,18 +30,25 @@ const RegisterForm: React.FC = (props: RegisterFormProps) => {
   } = useForm<RegisterFormInputs>();
 
   // 登録実行
-  // const onSubmit = () => {
-  //   createUser()
-  // }
+  const execSubmit = async (formData: RegisterFormInputs) => {
+    try {
+      console.log('formData', formData);
+      const response = await createUser(formData);
+      console.log('response', response);
+      if (props.onSuccess) props.onSuccess();
+    } catch (err) {
+      console.log('ユーザーの取得に失敗しました。', err);
+      if (props.onError) props.onError(err);
+    } 
+  };
 
   return (
-    <Box sx={{ maxWidth: 400, mx: "auto", mt: 4 }}>
+    <Box sx={{ maxWidth: 400, mx: "auto", mt: 4, textAlign: 'center' }}>
       <Typography  variant="h5" gutterBottom>
         新規登録
       </Typography>
 
-      {/* TODO: createUserを呼び出す為の関数を呼び出す必要がある */}
-      <form onSubmit={handleSubmit(props.onSuccess!, props.onError)}>
+      <form onSubmit={handleSubmit(execSubmit)}>
         <TextField label="User Name" sx={{m: 2}} {
           ...register('name', {required: '名前を入力してください'})
         }></TextField>

--- a/components/RegisterForm.tsx
+++ b/components/RegisterForm.tsx
@@ -6,7 +6,7 @@ import React, { useEffect, useState } from "react";
 import { useForm } from "react-hook-form";
 
 // 必要に応じて利用する
-interface RegisterFormInputs {
+export interface RegisterFormInputs {
   name: string;
   email: string;
   role: string;
@@ -14,7 +14,7 @@ interface RegisterFormInputs {
 
 // データ登録時ページ遷移情報
 interface RegisterFormProps {
- onSuccess: () => void;
+ onSuccess: (formData: RegisterFormInputs) => void;
  onError: (error: any) => void;
  disabled: boolean;
 }
@@ -39,8 +39,10 @@ const RegisterForm: React.FC<RegisterFormProps> = (props: RegisterFormProps) => 
   const execSubmit = async (formData: RegisterFormInputs) => {
     setRegisterBtnDistabled(true);
     try {
+      // エラー時動確用コード
+      // throw new Error("意図的なエラー発生")
       await createUser(formData);
-      props.onSuccess(); 
+      props.onSuccess(formData); 
     } catch (err) {
       props.onError(err);
       // ボタンを再押下可能に

--- a/components/UserCard.tsx
+++ b/components/UserCard.tsx
@@ -1,13 +1,40 @@
-import React from 'react';
-import { Card, CardContent, Typography, CardActions, Button } from '@mui/material';
-import { User } from '../types/User';
+import { deleteUser } from '@/utils/api';
+import { Button, Card, CardActions, CardContent, Dialog, DialogActions, DialogContent, DialogContentText, DialogTitle, Typography } from '@mui/material';
 import Link from 'next/link';
+import React from 'react';
+import { User } from '../types/User';
 
 interface UserCardProps {
   user: User;
 }
 
 const UserCard: React.FC<UserCardProps> = ({ user }) => {
+  const [openDeleteConfirm, setOpenDeleteConfirm] = React.useState(false);
+  const [selectedUser, setSelectedUser] = React.useState<User| null>();
+
+  const handleClickDeleteUser = (selectedUser: User) => {
+    setSelectedUser(selectedUser)
+    setOpenDeleteConfirm(true);
+  }
+
+  const handleCloseDeleteConfirm = () => {
+    setOpenDeleteConfirm(false);
+    setSelectedUser(null)
+  }
+
+  // ユーザー削除実行
+  const execDelete = async (selectedUser: User) => {
+    const targetUserName = selectedUser.name;
+    try {
+      await deleteUser(selectedUser.id);
+      alert(`ユーザー: ${targetUserName} を削除しました`)
+      window.location.reload();
+    } catch {
+      alert(`ユーザー: ${targetUserName} の削除に失敗しました`)
+    }
+    handleCloseDeleteConfirm()
+  }
+
   return (
     <Card sx={{ minWidth: 275, mb: 2 }}>
       <CardContent>
@@ -23,7 +50,30 @@ const UserCard: React.FC<UserCardProps> = ({ user }) => {
       </CardContent>
       <CardActions>
         <Button size="small" component={Link} href={`/users/${user.id}/edit`}>編集</Button>
-        <Button size="small" color="error">削除</Button>
+        <Button size="small" color="error" onClick={() => handleClickDeleteUser(user)}>削除</Button>
+        <Dialog
+          open={openDeleteConfirm}
+          onClose={handleCloseDeleteConfirm}
+          aria-labelledby="delete-confirm-dialog-title"
+          aria-describedby="delete-confirm-dialog-description"
+        >
+        <DialogTitle id="delete-confirm-dialog-title">
+          {"Delete User Confirm"}
+        </DialogTitle>
+        <DialogContent>
+          <DialogContentText id="delete-confirm-dialog-description" sx={{whiteSpace: 'pre-line' }}>
+            {`
+              User ID: ${selectedUser?.id} \n 
+              User Name: ${selectedUser?.name} \n
+              User Role: ${selectedUser?.role}
+            `}
+          </DialogContentText>
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={handleCloseDeleteConfirm}>キャンセル</Button>
+          <Button color="error" onClick={() => execDelete(selectedUser!)} autoFocus>削除</Button>
+        </DialogActions>
+      </Dialog>
       </CardActions>
     </Card>
   );


### PR DESCRIPTION
「タスク1-3：新規登録ページの作成」を実装しました。

## 対応内容
- [x] ：新規登録ページへのリンクが上部メニューに追加されている
- [x] ：タスク1-1のユーザー⼀覧画⾯に遷移する仕組みが実装されている
- [x] ：正常に動作している

## 別途PRで既に対応済みのもの
#1 にて以下は既に対応済みです
- [x] ：RegisterForm コンポーネントをレンダリングし、新規登録画⾯が表⽰できる
- [x] ：ページ全体のレイアウトが崩れていない

## 補足
#2 にて、仕様外のユーザー削除機能実装についてのコメントを入れています